### PR TITLE
PackageInfo.g: Remove Autoload & shorten AvailabilityTest

### DIFF
--- a/AdditionsForToricVarieties/PackageInfo.g
+++ b/AdditionsForToricVarieties/PackageInfo.g
@@ -60,7 +60,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to provide additional structures for toric varieties which are required to compute sheaf cohomologies",
-  Autoload  := false
 ),
 
 
@@ -77,14 +76,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "Toric Varieties, Sheaf cohomology" ],
 

--- a/CoherentSheavesOnToricVarieties/PackageInfo.g
+++ b/CoherentSheavesOnToricVarieties/PackageInfo.g
@@ -60,7 +60,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to model coherent toric sheaves as elements in a Serre quotient category.",
-  Autoload  := false
 ),
 
 
@@ -75,15 +74,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-  
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "coherent sheaves", "toric varieties" ],
 

--- a/Convex/PackageInfo.g
+++ b/Convex/PackageInfo.g
@@ -61,7 +61,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A Gap package for convex geometry via Polymake in Julia",
-  Autoload  := false
 ),
 
 
@@ -75,13 +74,7 @@ Dependencies := rec(
   ExternalConditions := [ ],
 ),
 
-AvailabilityTest := function()
-
-    return true;
-  end,
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "Convex geometry", "Polymake" ],
 

--- a/H0Approximator/PackageInfo.g
+++ b/H0Approximator/PackageInfo.g
@@ -81,7 +81,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to estimate global sections of a pullback line bundle on hypersurface curves in dP3 and H2",
-  Autoload  := false
 ),
 
 
@@ -95,15 +94,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-  
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "Coherent sheaves", "Line bundles", "delPezzo", "Hirzebruch", "sections" ],
 

--- a/QSMExplorer/PackageInfo.g
+++ b/QSMExplorer/PackageInfo.g
@@ -81,7 +81,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to explor one Quadrillion F-theory Standard Models",
-  Autoload  := false
 ),
 
 
@@ -95,15 +94,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-  
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "Polytopes", "root bundles", "limit roots", "nodal curves" ],
 

--- a/SheafCohomologyOnToricVarieties/PackageInfo.g
+++ b/SheafCohomologyOnToricVarieties/PackageInfo.g
@@ -62,7 +62,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to compute sheaf cohomology on toric varieties",
-  Autoload  := false
 ),
 
 
@@ -78,15 +77,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-  
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "Sheaf cohomology" ],
 

--- a/SparseMatrices/PackageInfo.g
+++ b/SparseMatrices/PackageInfo.g
@@ -60,7 +60,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to handle sparse matrices in gap",
-  Autoload  := false
 ),
 
 
@@ -73,15 +72,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-  
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "Sparse matrices", "Linear Algebra" ],
 

--- a/SpasmInterface/PackageInfo.g
+++ b/SpasmInterface/PackageInfo.g
@@ -60,7 +60,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to communicate with the software Spasm",
-  Autoload  := false
 ),
 
 
@@ -74,15 +73,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-  
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "Sparse matrices", "Linear Algebra" ],
 

--- a/ToolsForFPGradedModules/PackageInfo.g
+++ b/ToolsForFPGradedModules/PackageInfo.g
@@ -60,7 +60,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to provide additional structures and tools for FPGradedModules",
-  Autoload  := false
 ),
 
 
@@ -77,14 +76,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "FPGradedModules, Ideals, Resolutions, Betti tables" ],
 

--- a/ToricVarieties/PackageInfo.g
+++ b/ToricVarieties/PackageInfo.g
@@ -93,7 +93,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to compute properties of toric varieties",
-  Autoload  := false
 ),
 
 
@@ -112,14 +111,7 @@ Dependencies := rec(
   
 ),
 
-AvailabilityTest := function()
-  
-    return true;
-  end,
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "Toric geometry", "Toric varieties", "Divisors", "Geometry"],
 

--- a/TruncationsOfFPGradedModules/PackageInfo.g
+++ b/TruncationsOfFPGradedModules/PackageInfo.g
@@ -60,7 +60,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to compute truncations of FPGradedModules",
-  Autoload  := false
 ),
 
 
@@ -75,14 +74,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "FPGradedModules, Truncations" ],
 

--- a/cohomCalgInterface/PackageInfo.g
+++ b/cohomCalgInterface/PackageInfo.g
@@ -60,7 +60,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A package to communicate with the software cohomCalg",
-  Autoload  := false
 ),
 
 
@@ -74,15 +73,7 @@ Dependencies := rec(
 
 ),
 
-AvailabilityTest := function()
-  
-    return true;
-  end,
-
-
-
-Autoload := false,
-
+AvailabilityTest := ReturnTrue,
 
 Keywords := [ "cohomCalg", "line bundle cohomology" ],
 


### PR DESCRIPTION
Autoload has long been obsolete and doesn't do anything anymore.