### PR TITLE
Replace `Julia.Polymake` -> `Polymake` in Julia code

### DIFF
--- a/JConvex/gap/ExternalPolymakeCone.gi
+++ b/JConvex/gap/ExternalPolymakeCone.gi
@@ -594,7 +594,7 @@ InstallMethod( Polymake_V_Rep_command_string,
         
         # prepare rays (always non-zero) for command string
         rays := List( [ 1 .. Length( rays ) ], i -> ReplacedString( ReplacedString( ReplacedString( String( rays[ i ] ), ",", "" ), "[ ", "" ), " ]", "" ) );
-        command_string := Concatenation( "ConeByGAP4PackageConvex", " = Julia.Polymake.polytope.Cone( INPUT_RAYS = [ ", JoinStringsWithSeparator( rays, "; " ), "] " );
+        command_string := Concatenation( "ConeByGAP4PackageConvex", " = Polymake.polytope.Cone( INPUT_RAYS = [ ", JoinStringsWithSeparator( rays, "; " ), "] " );
         
         # if we also have lineality, add them
         lin := cone!.lineality;
@@ -630,7 +630,7 @@ InstallMethod( Polymake_H_Rep_command_string,
         
         # prepare inequalities (always non-zero) for command string
         ineqs := List( [ 1 .. Length( ineqs ) ], i -> ReplacedString( ReplacedString( ReplacedString( String( ineqs[ i ] ), ",", "" ), "[ ", "" ), " ]", "" ) );
-        command_string := Concatenation( "ConeByGAP4PackageConvex", " = Julia.Polymake.polytope.Cone( INEQUALITIES = [ ", JoinStringsWithSeparator( ineqs, "; " ), " ] " );
+        command_string := Concatenation( "ConeByGAP4PackageConvex", " = Polymake.polytope.Cone( INEQUALITIES = [ ", JoinStringsWithSeparator( ineqs, "; " ), " ] " );
         
         # if we have non-zero equalities, add them
         eqs := cone!.equalities;

--- a/JConvex/gap/ExternalPolymakePolytope.gi
+++ b/JConvex/gap/ExternalPolymakePolytope.gi
@@ -550,7 +550,7 @@ InstallMethod( Polymake_V_Rep_command_string,
         
         # prepare string with vertices -- as polymake considers them affine, we have to add a 1 at the beginning
         new_vertices := List( [ 1 .. Length( new_vertices ) ], i -> ReplacedString( ReplacedString( ReplacedString( String( new_vertices[ i ] ), ",", "" ), "[ ", "" ), " ]", "" ) );
-        command_string := Concatenation( "PolytopeByGAP4PackageConvex", " = Julia.Polymake.polytope.Polytope( POINTS = [ ", JoinStringsWithSeparator( new_vertices, "; " ), "] " );
+        command_string := Concatenation( "PolytopeByGAP4PackageConvex", " = Polymake.polytope.Polytope( POINTS = [ ", JoinStringsWithSeparator( new_vertices, "; " ), "] " );
         
         # see if we need lineality
         if ( Length( new_lin ) > 0 ) then
@@ -585,7 +585,7 @@ InstallMethod( Polymake_H_Rep_command_string,
         
         # prepare string with inequalities
         ineqs := List( [ 1 .. Length( ineqs ) ], i -> ReplacedString( ReplacedString( ReplacedString( String( ineqs[ i ] ), ",", "" ), "[ ", "" ), " ]", "" ) );
-        command_string := Concatenation( "PolytopeByGAP4PackageConvex", " = Julia.Polymake.polytope.Polytope( INEQUALITIES = [ ", JoinStringsWithSeparator( ineqs, "; " ), " ] " );
+        command_string := Concatenation( "PolytopeByGAP4PackageConvex", " = Polymake.polytope.Polytope( INEQUALITIES = [ ", JoinStringsWithSeparator( ineqs, "; " ), " ] " );
         
         # check if we also need equalities
         if ( Length( eqs ) > 0 ) then


### PR DESCRIPTION
I am not sure why the old code ever worked; I can only guess that some code
somewhere exports the GAP global variable `Julia` into the Julia main module.