### PR TITLE
Refactor JToric

### DIFF
--- a/JConvex/gap/ExternalPolymakeCone.gd
+++ b/JConvex/gap/ExternalPolymakeCone.gd
@@ -153,22 +153,3 @@ DeclareProperty( "Polymake_IsPointed", IsPolymakeCone );
 #! @Description
 #! Returns the Polymake cone that defines the intersection of the two cones.
 DeclareOperation( "Polymake_Intersection", [ IsPolymakeCone, IsPolymakeCone ] );
-
-
-##############################################################################################
-##
-#! @Section Command strings
-##
-##############################################################################################
-
-#! @Arguments C
-#! @Returns a string
-#! @Description
-#! Returns the string which, when executed in Julia, constructs the cone in question as H-representation.
-DeclareOperation( "Polymake_H_Rep_command_string", [ IsPolymakeCone ] );
-
-#! @Arguments C
-#! @Returns a string
-#! @Description
-#! Returns the string which, when executed in Julia, constructs the cone in question as V-representation.
-DeclareOperation( "Polymake_V_Rep_command_string", [ IsPolymakeCone ] );

--- a/JConvex/gap/ExternalPolymakeCone.gi
+++ b/JConvex/gap/ExternalPolymakeCone.gi
@@ -25,19 +25,31 @@ BindGlobal( "TheFamilyOfPolymakeCones", NewFamily( "TheFamilyOfPolymakeCones" ) 
 BindGlobal( "TheTypeOfPolymakeCone", NewType( TheFamilyOfPolymakeCones, IsPolymakeConeRep ) );
 
 BindGlobal( "MakePolymakeConeVRep", function( rays, lineality )
-    return Objectify( TheTypeOfPolymakeCone,
+    local cone;
+    cone := Objectify( TheTypeOfPolymakeCone,
             rec( rays := Immutable( rays ),
                  lineality := Immutable( lineality ),
                  number_type := "rational",
                  rep_type := "V-rep" ) );
+
+    if Length(rays) = 0 and Length(lineality) = 0 then
+        cone!.pmobj := _Polymake_jl.polytope.Cone();
+    else
+        cone!.pmobj := JuliaEvalString( Polymake_V_Rep_command_string( cone ) );
+    fi;
+    return cone;
 end);
 
 BindGlobal( "MakePolymakeConeHRep", function( inequalities, equalities )
-    return Objectify( TheTypeOfPolymakeCone,
+    local cone;
+    cone := Objectify( TheTypeOfPolymakeCone,
             rec( inequalities := Immutable( inequalities ),
                  equalities := Immutable( equalities ),
                  number_type := "rational",
                  rep_type := "H-rep" ) );
+
+    cone!.pmobj := JuliaEvalString( Polymake_H_Rep_command_string( cone ) );
+    return cone;
 end);
 
 

--- a/JConvex/gap/ExternalPolymakeCone.gi
+++ b/JConvex/gap/ExternalPolymakeCone.gi
@@ -24,6 +24,22 @@ BindGlobal( "TheFamilyOfPolymakeCones", NewFamily( "TheFamilyOfPolymakeCones" ) 
 
 BindGlobal( "TheTypeOfPolymakeCone", NewType( TheFamilyOfPolymakeCones, IsPolymakeConeRep ) );
 
+BindGlobal( "MakePolymakeConeVRep", function( rays, lineality )
+    return Objectify( TheTypeOfPolymakeCone,
+            rec( rays := rays,
+                 lineality := lineality,
+                 number_type := "rational",
+                 rep_type := "V-rep" ) );
+end);
+
+BindGlobal( "MakePolymakeConeHRep", function( inequalities, equalities )
+    return Objectify( TheTypeOfPolymakeCone,
+            rec( inequalities := inequalities,
+                 equalities := equalities,
+                 number_type := "rational",
+                 rep_type := "H-rep" ) );
+end);
+
 
 ##############################################################################################
 ##
@@ -50,11 +66,7 @@ InstallGlobalFunction( Polymake_ConeByGenerators,
         else
             
             # received the trivial cone
-            cone := rec( rays := [ ],
-                         lineality := [ ],
-                         number_type := "rational",
-                         rep_type := "V-rep" );
-            ObjectifyWithAttributes( cone, TheTypeOfPolymakeCone );
+            cone := MakePolymakeConeVRep( [ ], [ ] );
             return cone;
             
         fi;
@@ -71,12 +83,7 @@ InstallGlobalFunction( Polymake_ConeByGenerators,
         
         given_rays := Filtered( arg[ 1 ], row -> not IsZero( row ) );
         given_lineality := Filtered( arg[ 2 ], row -> not IsZero( row ) );
-        cone := rec( rays := given_rays,
-                     lineality := given_lineality,
-                     number_type := "rational",
-                     rep_type := "V-rep" );
-        ObjectifyWithAttributes( cone, TheTypeOfPolymakeCone );
-        
+        cone := MakePolymakeConeVRep( given_rays, given_lineality );
         return Polymake_CanonicalConeByGenerators( cone );
         
     fi;
@@ -107,12 +114,7 @@ InstallGlobalFunction( Polymake_ConeFromInequalities,
         
         given_ineqs := Filtered( arg[ 1 ], row -> not IsZero( row ) );
         given_eqs := Filtered( arg[ 2 ], row -> not IsZero( row ) );
-        cone := rec( inequalities := given_ineqs,
-                     equalities := given_eqs,
-                     number_type := "rational",
-                     rep_type := "H-rep" );
-        ObjectifyWithAttributes( cone, TheTypeOfPolymakeCone );
-        
+        cone := MakePolymakeConeHRep( given_ineqs, given_eqs );
         return Polymake_CanonicalConeFromInequalities( cone );
         
     fi;
@@ -168,11 +170,7 @@ InstallMethod( Polymake_CanonicalConeByGenerators,
         od;
         
         # construct the new cone
-        new_cone := rec( rays := scaled_rays,
-                         lineality := scaled_lineality,
-                         number_type := "rational",
-                         rep_type := "V-rep" );
-        ObjectifyWithAttributes( new_cone, TheTypeOfPolymakeCone );
+        new_cone := MakePolymakeConeVRep( scaled_rays, scaled_lineality );
         return new_cone;
         
     fi;
@@ -221,11 +219,7 @@ InstallMethod( Polymake_CanonicalConeFromInequalities,
         od;
         
         # construct the new cone
-        new_cone := rec( inequalities := scaled_ineqs,
-                         equalities := scaled_eqs,
-                         number_type := "rational",
-                         rep_type := "H-rep" );
-        ObjectifyWithAttributes( new_cone, TheTypeOfPolymakeCone );
+        new_cone := MakePolymakeConeHRep( scaled_ineqs, scaled_eqs );
         return new_cone;
         
     fi;
@@ -279,11 +273,7 @@ InstallMethod( Polymake_V_Rep,
         od;
         
         # construct the new cone
-        new_cone := rec( rays := scaled_rays,
-                         lineality := scaled_lineality,
-                         number_type := "rational",
-                         rep_type := "V-rep" );
-        ObjectifyWithAttributes( new_cone, TheTypeOfPolymakeCone );
+        new_cone := MakePolymakeConeVRep( scaled_rays, scaled_lineality );
         return new_cone;
         
     fi;
@@ -336,11 +326,7 @@ InstallMethod( Polymake_H_Rep,
         od;
         
         # construct the new cone
-        new_cone := rec( inequalities := scaled_ineqs,
-                         equalities := scaled_eqs,
-                         number_type := "rational",
-                         rep_type := "H-rep" );
-        ObjectifyWithAttributes( new_cone, TheTypeOfPolymakeCone );
+        new_cone := MakePolymakeConeHRep( scaled_ineqs, scaled_eqs );
         return new_cone;
         
     fi;

--- a/JConvex/gap/ExternalPolymakeCone.gi
+++ b/JConvex/gap/ExternalPolymakeCone.gi
@@ -143,7 +143,7 @@ end );
 InstallMethod( Polymake_CanonicalConeByGenerators,
                [ IsPolymakeCone ],
   function( cone )
-    local command_string, s, res_string, rays, scaled_rays, i, scale, lineality, scaled_lineality, new_cone;
+    local s, res_string, rays, scaled_rays, i, scale, lineality, scaled_lineality, new_cone;
     
     if cone!.rep_type = "H-rep" then
         
@@ -152,9 +152,7 @@ InstallMethod( Polymake_CanonicalConeByGenerators,
     else
         
         # compute rays
-        command_string := Concatenation( Polymake_V_Rep_command_string( cone ), ".RAYS" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.RAYS ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         rays := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -167,9 +165,7 @@ InstallMethod( Polymake_CanonicalConeByGenerators,
         od;
         
         # extract lineality
-        command_string := Concatenation( Polymake_V_Rep_command_string( cone ), ".LINEALITY_SPACE" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.LINEALITY_SPACE ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         lineality := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -192,7 +188,7 @@ end );
 InstallMethod( Polymake_CanonicalConeFromInequalities,
                [ IsPolymakeCone ],
   function( cone )
-    local command_string, s, res_string, ineqs, scaled_ineqs, i, scale, eqs, scaled_eqs, new_cone;
+    local s, res_string, ineqs, scaled_ineqs, i, scale, eqs, scaled_eqs, new_cone;
     
     if cone!.rep_type = "V-rep" then
         
@@ -201,9 +197,7 @@ InstallMethod( Polymake_CanonicalConeFromInequalities,
     else
         
         # compute facets
-        command_string := Concatenation( Polymake_H_Rep_command_string( cone ), ".FACETS" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.FACETS ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         ineqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -216,9 +210,7 @@ InstallMethod( Polymake_CanonicalConeFromInequalities,
         od;
         
         # compute linear span
-        command_string := Concatenation( Polymake_H_Rep_command_string( cone ), ".LINEAR_SPAN" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.LINEAR_SPAN ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         eqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -248,16 +240,14 @@ end );
 InstallMethod( Polymake_V_Rep,
                [ IsPolymakeCone ],
   function( cone )
-    local command_string, s, res_string, rays, scaled_rays, i, scale, lineality, scaled_lineality, new_cone;
+    local s, res_string, rays, scaled_rays, i, scale, lineality, scaled_lineality, new_cone;
     
     if cone!.rep_type = "V-rep" then
         return cone;
     else
         
         # compute rays
-        command_string := Concatenation( Polymake_H_Rep_command_string( cone ), ".RAYS" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.RAYS ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         rays := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -270,9 +260,7 @@ InstallMethod( Polymake_V_Rep,
         od;
         
         # extract lineality
-        command_string := Concatenation( Polymake_H_Rep_command_string( cone ), ".LINEALITY_SPACE" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.LINEALITY_SPACE ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         lineality := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -295,7 +283,7 @@ end );
 InstallMethod( Polymake_H_Rep,
                [ IsPolymakeCone ],
   function( cone )
-    local command_string, s, res_string, ineqs, scaled_ineqs, i, scale, eqs, scaled_eqs, new_cone;
+    local s, res_string, ineqs, scaled_ineqs, i, scale, eqs, scaled_eqs, new_cone;
     
     if cone!.rep_type = "H-rep" then
         
@@ -308,9 +296,7 @@ InstallMethod( Polymake_H_Rep,
         fi;
         
         # compute facets
-        command_string := Concatenation( Polymake_V_Rep_command_string( cone ), ".FACETS" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.FACETS ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         ineqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -323,9 +309,7 @@ InstallMethod( Polymake_H_Rep,
         od;
         
         # compute linear span
-        command_string := Concatenation( Polymake_V_Rep_command_string( cone ), ".LINEAR_SPAN" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.LINEAR_SPAN ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         eqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -366,16 +350,12 @@ InstallMethod( Polymake_Dimension,
               " returns the dimension of the cone",
             [ IsPolymakeCone ],
   function( cone )
-    local command_string, s;
     
     if Polymake_IsEmpty( cone ) then 
         return -1;
     fi;
     
-    command_string := Concatenation( Polymake_V_Rep_command_string( Polymake_V_Rep( cone ) ), ".CONE_DIM" );
-    JuliaEvalString( command_string );
-    s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
-    return EvalString( s );
+    return cone!.pmobj.CONE_DIM;
     
 end );
 
@@ -424,16 +404,11 @@ InstallMethod( Polymake_RaysInFacets,
               " returns the incident matrix of the rays in the facets",
             [ IsPolymakeCone ],
   function( cone )
-    local help_cone, command_string, s, res_string, number_rays, ray_list, i, dummy, j, helper;
+    local help_cone, s, res_string, number_rays, ray_list, i, dummy, j, helper;
     
-    # produce command string
     help_cone := Polymake_V_Rep( cone );
     number_rays := Length( help_cone!.rays );
-    command_string := Concatenation( Polymake_V_Rep_command_string( help_cone ), ".RAYS_IN_FACETS" );
-    
-    # issue command in Julia and fetch result
-    JuliaEvalString( command_string );
-    s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
+    s := JuliaToGAP( IsString, Julia.string( help_cone!.pmobj.RAYS_IN_FACETS ) );
     
     # process the string
     res_string := SplitString( s, '\n' );
@@ -531,18 +506,11 @@ InstallMethod( Polymake_IsPointed,
                "finding if the cone is pointed or not",
                [ IsPolymakeCone ],
   function( cone )
-    local help_cone, rays, lin, command_string, s;
+    local help_cone;
     
-    # compute V-representation
     help_cone := Polymake_V_Rep( cone );
     
-    # parse the rays into format recognized by Polymake
-    command_string := Concatenation( Polymake_V_Rep_command_string( help_cone ), ".POINTED" );
-    JuliaEvalString( command_string );
-    s := JuliaToGAP( IsString, Julia.string( Julia.ConeByGAP4PackageConvex ) );
-    
-    # return the result
-    return EvalString( s );
+    return help_cone!.pmobj.POINTED;
     
 end );
 

--- a/JConvex/gap/ExternalPolymakeCone.gi
+++ b/JConvex/gap/ExternalPolymakeCone.gi
@@ -26,16 +26,16 @@ BindGlobal( "TheTypeOfPolymakeCone", NewType( TheFamilyOfPolymakeCones, IsPolyma
 
 BindGlobal( "MakePolymakeConeVRep", function( rays, lineality )
     return Objectify( TheTypeOfPolymakeCone,
-            rec( rays := rays,
-                 lineality := lineality,
+            rec( rays := Immutable( rays ),
+                 lineality := Immutable( lineality ),
                  number_type := "rational",
                  rep_type := "V-rep" ) );
 end);
 
 BindGlobal( "MakePolymakeConeHRep", function( inequalities, equalities )
     return Objectify( TheTypeOfPolymakeCone,
-            rec( inequalities := inequalities,
-                 equalities := equalities,
+            rec( inequalities := Immutable( inequalities ),
+                 equalities := Immutable( equalities ),
                  number_type := "rational",
                  rep_type := "H-rep" ) );
 end);

--- a/JConvex/gap/ExternalPolymakeCone.gi
+++ b/JConvex/gap/ExternalPolymakeCone.gi
@@ -184,10 +184,7 @@ InstallMethod( Polymake_CanonicalConeByGenerators,
     else
         
         # compute rays
-        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.RAYS ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        rays := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        rays := JuliaToGAP( IsList, JuliaMatrixInt( cone!.pmobj.RAYS ) );
         
         # sometimes, Polymake returns rational rays - we turn them into integral vectors
         scaled_rays := [];
@@ -197,10 +194,7 @@ InstallMethod( Polymake_CanonicalConeByGenerators,
         od;
         
         # extract lineality
-        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.LINEALITY_SPACE ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        lineality := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        lineality := JuliaToGAP( IsList, JuliaMatrixInt( cone!.pmobj.LINEALITY_SPACE ) );
         
         # sometimes, Polymake returns rational lineality - we turn them into integral vectors
         scaled_lineality := [];
@@ -229,10 +223,7 @@ InstallMethod( Polymake_CanonicalConeFromInequalities,
     else
         
         # compute facets
-        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.FACETS ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        ineqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        ineqs := JuliaToGAP( IsList, JuliaMatrixInt( cone!.pmobj.FACETS ) );
         
         # sometimes, Polymake returns rational facets - we turn them into integral vectors
         scaled_ineqs := [];
@@ -242,10 +233,7 @@ InstallMethod( Polymake_CanonicalConeFromInequalities,
         od;
         
         # compute linear span
-        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.LINEAR_SPAN ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        eqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        eqs := JuliaToGAP( IsList, JuliaMatrixInt( cone!.pmobj.LINEAR_SPAN ) );
         
         # sometimes, Polymake returns rational linear spans - we turn them into integral vectors
         scaled_eqs := [];
@@ -279,10 +267,7 @@ InstallMethod( Polymake_V_Rep,
     else
         
         # compute rays
-        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.RAYS ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        rays := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        rays := JuliaToGAP( IsList, JuliaMatrixInt( cone!.pmobj.RAYS ) );
         
         # sometimes, Polymake returns rational rays - we turn them into integral vectors
         scaled_rays := [];
@@ -292,10 +277,7 @@ InstallMethod( Polymake_V_Rep,
         od;
         
         # extract lineality
-        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.LINEALITY_SPACE ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        lineality := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        lineality := JuliaToGAP( IsList, JuliaMatrixInt( cone!.pmobj.LINEALITY_SPACE ) );
         
         # sometimes, Polymake returns rational lineality - we turn them into integral vectors
         scaled_lineality := [];
@@ -328,10 +310,7 @@ InstallMethod( Polymake_H_Rep,
         fi;
         
         # compute facets
-        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.FACETS ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        ineqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        ineqs := JuliaToGAP( IsList, JuliaMatrixInt( cone!.pmobj.FACETS ) );
         
         # sometimes, Polymake returns rational facets - we turn them into integral vectors
         scaled_ineqs := [];
@@ -341,10 +320,7 @@ InstallMethod( Polymake_H_Rep,
         od;
         
         # compute linear span
-        s := JuliaToGAP( IsString, Julia.string( cone!.pmobj.LINEAR_SPAN ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        eqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        eqs := JuliaToGAP( IsList, JuliaMatrixInt( cone!.pmobj.LINEAR_SPAN ) );
         
         # sometimes, Polymake returns rational linear spans - we turn them into integral vectors
         scaled_eqs := [];
@@ -510,7 +486,7 @@ InstallMethod( Polymake_RaysInFaces,
     fi;
     
     # all all rays, since the overall cone is also a face
-    rays_in_faces := Concatenation( rays_in_faces, [ List( [ 1 .. Length( Polymake_Rays( cone ) ) ], i -> 1 ) ] );
+    rays_in_faces := Concatenation( rays_in_faces, [ ListWithIdenticalEntries( Length( Polymake_Rays( cone ) ), 1 ) ] );
     
     # return the result
     return DuplicateFreeList( rays_in_faces );

--- a/JConvex/gap/ExternalPolymakePolytope.gd
+++ b/JConvex/gap/ExternalPolymakePolytope.gd
@@ -148,22 +148,3 @@ DeclareProperty( "Polymake_IsBounded", IsPolymakePolytope );
 #! @Description
 #! The output is the intersection of P1 and P2.
 DeclareOperation( "Polymake_Intersection", [ IsPolymakePolytope, IsPolymakePolytope ] );
-
-
-##############################################################################################
-##
-#! @Section Command strings
-##
-##############################################################################################
-
-#! @Arguments C
-#! @Returns a string
-#! @Description
-#! Returns the string which, when executed in Julia, constructs the polytope in question as H-representation.
-DeclareOperation( "Polymake_H_Rep_command_string", [ IsPolymakePolytope ] );
-
-#! @Arguments C
-#! @Returns a string
-#! @Description
-#! Returns the string which, when executed in Julia, constructs the polytope in question as V-representation.
-DeclareOperation( "Polymake_V_Rep_command_string", [ IsPolymakePolytope ] );

--- a/JConvex/gap/ExternalPolymakePolytope.gi
+++ b/JConvex/gap/ExternalPolymakePolytope.gi
@@ -26,16 +26,16 @@ BindGlobal( "TheTypeOfPolymakePolytope", NewType( TheFamilyOfPolymakePolytopes, 
 
 BindGlobal( "MakePolymakePolytopeVRep", function( vertices, lineality )
     return Objectify( TheTypeOfPolymakePolytope,
-            rec( vertices := vertices,
-                 lineality := lineality,
+            rec( vertices := Immutable( vertices ),
+                 lineality := Immutable( lineality ),
                  number_type := "rational",
                  rep_type := "V-rep" ) );
 end);
 
 BindGlobal( "MakePolymakePolytopeHRep", function( inequalities, equalities )
     return Objectify( TheTypeOfPolymakePolytope,
-            rec( inequalities := inequalities,
-                 equalities := equalities,
+            rec( inequalities := Immutable( inequalities ),
+                 equalities := Immutable( equalities ),
                  number_type := "rational",
                  rep_type := "H-rep" ) );
 end);

--- a/JConvex/gap/ExternalPolymakePolytope.gi
+++ b/JConvex/gap/ExternalPolymakePolytope.gi
@@ -125,7 +125,7 @@ end );
 InstallMethod( Polymake_CanonicalPolytopeByGenerators,
                [ IsPolymakePolytope ],
   function( poly )
-    local command_string, s, res_string, vertices, v_copy, scaled_vertices, i, scale, lineality, scaled_lineality, new_poly;
+    local s, res_string, vertices, v_copy, scaled_vertices, i, scale, lineality, scaled_lineality, new_poly;
     
     if poly!.rep_type = "H-rep" then
         
@@ -134,9 +134,7 @@ InstallMethod( Polymake_CanonicalPolytopeByGenerators,
     else
         
         # compute vertices
-        command_string := Concatenation( Polymake_V_Rep_command_string( poly ), ".VERTICES" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.VERTICES ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         vertices := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -152,9 +150,7 @@ InstallMethod( Polymake_CanonicalPolytopeByGenerators,
         od;
         
         # extract lineality
-        command_string := Concatenation( Polymake_V_Rep_command_string( poly ), ".LINEALITY_SPACE" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.LINEALITY_SPACE ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         lineality := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -179,7 +175,7 @@ end );
 InstallMethod( Polymake_CanonicalPolytopeFromInequalities,
                [ IsPolymakePolytope ],
   function( poly )
-    local command_string, s, res_string, ineqs, scaled_ineqs, i, scale, eqs, scaled_eqs, new_poly;
+    local s, res_string, ineqs, scaled_ineqs, i, scale, eqs, scaled_eqs, new_poly;
     
     if poly!.rep_type = "V-rep" then
         
@@ -188,9 +184,7 @@ InstallMethod( Polymake_CanonicalPolytopeFromInequalities,
     else
         
         # compute facets
-        command_string := Concatenation( Polymake_H_Rep_command_string( poly ), ".FACETS" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.FACETS ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         ineqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -203,9 +197,7 @@ InstallMethod( Polymake_CanonicalPolytopeFromInequalities,
         od;
         
         # compute affine hull
-        command_string := Concatenation( Polymake_H_Rep_command_string( poly ), ".AFFINE_HULL" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.AFFINE_HULL ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         eqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -235,7 +227,7 @@ end );
 InstallMethod( Polymake_V_Rep,
                [ IsPolymakePolytope ],
   function( poly )
-    local command_string, s, res_string, vertices, v_copy, scaled_vertices, i, scale, lineality, scaled_lineality, new_poly;
+    local s, res_string, vertices, v_copy, scaled_vertices, i, scale, lineality, scaled_lineality, new_poly;
     
     if poly!.rep_type = "V-rep" then
         
@@ -244,9 +236,7 @@ InstallMethod( Polymake_V_Rep,
     else
         
         # compute vertices
-        command_string := Concatenation( Polymake_H_Rep_command_string( poly ), ".VERTICES" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.VERTICES ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         vertices := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -261,9 +251,7 @@ InstallMethod( Polymake_V_Rep,
         od;
         
         # compute lineality
-        command_string := Concatenation( Polymake_H_Rep_command_string( poly ), ".LINEALITY_SPACE" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.LINEALITY_SPACE ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         lineality := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -289,7 +277,7 @@ end );
 InstallMethod( Polymake_H_Rep,
                [ IsPolymakePolytope ],
   function( poly )
-    local command_string, s, res_string, ineqs, i, scale, scaled_ineqs, eqs, scaled_eqs, new_poly;
+    local s, res_string, ineqs, i, scale, scaled_ineqs, eqs, scaled_eqs, new_poly;
     
     if poly!.rep_type = "H-rep" then
         
@@ -302,9 +290,7 @@ InstallMethod( Polymake_H_Rep,
         fi;
         
         # compute inequalities
-        command_string := Concatenation( Polymake_V_Rep_command_string( poly ), ".FACETS" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.FACETS ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         ineqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -317,9 +303,7 @@ InstallMethod( Polymake_H_Rep,
         od;
         
         # compute equalities
-        command_string := Concatenation( Polymake_V_Rep_command_string( poly ), ".AFFINE_HULL" );
-        JuliaEvalString( command_string );
-        s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
+        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.AFFINE_HULL ) );
         res_string := SplitString( s, '\n' );
         res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
         eqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -360,17 +344,12 @@ InstallMethod( Polymake_Dimension,
               " returns the dimension of the poly",
             [ IsPolymakePolytope ],
   function( poly )
-    local command_string, s;
     
     if Polymake_IsEmpty( poly ) then
         return -1;
     fi;
     
-    # produce command string
-    command_string := Concatenation( Polymake_V_Rep_command_string( Polymake_V_Rep( poly ) ), ".CONE_DIM" );
-    JuliaEvalString( command_string );
-    s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
-    return EvalString( s ) - 1;
+    return poly!.pmobj.CONE_DIM - 1;
     
 end );
 
@@ -419,14 +398,9 @@ InstallMethod( Polymake_LatticePoints,
               " return the list of the lattice points of poly",
               [ IsPolymakePolytope ],
   function( poly )
-    local command_string, s, res_string, point_list, lattice_points, i, copy;
+    local s, res_string, point_list, lattice_points, i, copy;
     
-    # produce command string
-    command_string := Concatenation( Polymake_V_Rep_command_string( Polymake_V_Rep( poly ) ), ".LATTICE_POINTS_GENERATORS" );
-    
-    # issue command in Julia and fetch result
-    JuliaEvalString( command_string );
-    s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
+    s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.LATTICE_POINTS_GENERATORS ) );
     res_string := SplitString( s, '\n' );
     res_string := List( [ 2 .. Length( res_string ) - 3 ], i -> Concatenation( "[", ReplacedString( ReplacedString( res_string[ i ], " ", "," ), "<", "" ), "]" ) );
     point_list := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
@@ -484,12 +458,7 @@ InstallMethod( Polymake_IsPointed,
                "finding if the poly is pointed or not",
                [ IsPolymakePolytope ],
   function( poly )
-    local command_string, s;
-    
-    command_string := Concatenation( Polymake_V_Rep_command_string( Polymake_V_Rep( poly ) ), ".POINTED" );
-    JuliaEvalString( command_string );
-    s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
-    return EvalString( s );
+    return poly!.pmobj.POINTED;
     
 end );
 
@@ -498,12 +467,7 @@ InstallMethod( Polymake_IsBounded,
               " returns if the polytope is bounded or not",
               [ IsPolymakePolytope ],
   function( poly )
-    local command_string, s;
-    
-    command_string := Concatenation( Polymake_H_Rep_command_string( Polymake_H_Rep( poly ) ), ".BOUNDED" );
-    JuliaEvalString( command_string );
-    s := JuliaToGAP( IsString, Julia.string( Julia.PolytopeByGAP4PackageConvex ) );
-    return EvalString( s );
+    return poly!.pmobj.BOUNDED;
     
 end );
 

--- a/JConvex/gap/ExternalPolymakePolytope.gi
+++ b/JConvex/gap/ExternalPolymakePolytope.gi
@@ -182,10 +182,7 @@ InstallMethod( Polymake_CanonicalPolytopeByGenerators,
     else
         
         # compute vertices
-        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.VERTICES ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        vertices := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        vertices := JuliaToGAP( IsList, JuliaMatrixInt( poly!.pmobj.VERTICES ) );
         
         # sometimes, Polymake returns rational vertices - we turn them into integral vectors
         # also, Polymake requires x0 = 1 in affine coordinates - we remove this 1
@@ -198,10 +195,7 @@ InstallMethod( Polymake_CanonicalPolytopeByGenerators,
         od;
         
         # extract lineality
-        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.LINEALITY_SPACE ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        lineality := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        lineality := JuliaToGAP( IsList, JuliaMatrixInt( poly!.pmobj.LINEALITY_SPACE ) );
         
         # sometimes, Polymake returns rational lineality - we turn them into integral vectors
         scaled_lineality := [];
@@ -232,10 +226,7 @@ InstallMethod( Polymake_CanonicalPolytopeFromInequalities,
     else
         
         # compute facets
-        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.FACETS ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        ineqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        ineqs := JuliaToGAP( IsList, JuliaMatrixInt( poly!.pmobj.FACETS ) );
         
         # sometimes, Polymake returns rational facets - we turn them into integral vectors
         scaled_ineqs := [];
@@ -245,10 +236,7 @@ InstallMethod( Polymake_CanonicalPolytopeFromInequalities,
         od;
         
         # compute affine hull
-        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.AFFINE_HULL ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        eqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        eqs := JuliaToGAP( IsList, JuliaMatrixInt( poly!.pmobj.AFFINE_HULL ) );
         
         # sometimes, Polymake returns rational affine hulls - we turn them into integral vectors
         scaled_eqs := [];
@@ -284,10 +272,7 @@ InstallMethod( Polymake_V_Rep,
     else
         
         # compute vertices
-        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.VERTICES ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        vertices := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        vertices := JuliaToGAP( IsList, JuliaMatrixInt( poly!.pmobj.VERTICES ) );
         
         # sometimes, Polymake returns rational vertices - we turn them into integral vectors
         scaled_vertices := [];
@@ -299,10 +284,7 @@ InstallMethod( Polymake_V_Rep,
         od;
         
         # compute lineality
-        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.LINEALITY_SPACE ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        lineality := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        lineality := JuliaToGAP( IsList, JuliaMatrixInt( poly!.pmobj.LINEALITY_SPACE ) );
         
         # sometimes, Polymake returns rational lineality - we turn them into integral vectors
         scaled_lineality := [];
@@ -338,10 +320,7 @@ InstallMethod( Polymake_H_Rep,
         fi;
         
         # compute inequalities
-        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.FACETS ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        ineqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        ineqs := JuliaToGAP( IsList, JuliaMatrixInt( poly!.pmobj.FACETS ) );
         
         # sometimes, Polymake returns rational facets - we turn them into integral vectors
         scaled_ineqs := [];
@@ -351,10 +330,7 @@ InstallMethod( Polymake_H_Rep,
         od;
         
         # compute equalities
-        s := JuliaToGAP( IsString, Julia.string( poly!.pmobj.AFFINE_HULL ) );
-        res_string := SplitString( s, '\n' );
-        res_string := List( [ 2 .. Length( res_string ) ], i -> Concatenation( "[", ReplacedString( res_string[ i ], " ", "," ), "]" ) );
-        eqs := EvalString( Concatenation( "[", JoinStringsWithSeparator( res_string, "," ), "]" ) );
+        eqs := JuliaToGAP( IsList, JuliaMatrixInt( poly!.pmobj.AFFINE_HULL ) );
         
         # sometimes, Polymake returns rational affine hulls - we turn them into integral vectors
         scaled_eqs := [];

--- a/JConvex/gap/ExternalPolymakePolytope.gi
+++ b/JConvex/gap/ExternalPolymakePolytope.gi
@@ -24,6 +24,22 @@ BindGlobal( "TheFamilyOfPolymakePolytopes", NewFamily( "TheFamilyOfPolymakePolyt
 
 BindGlobal( "TheTypeOfPolymakePolytope", NewType( TheFamilyOfPolymakePolytopes, IsPolymakePolytopeRep ) );
 
+BindGlobal( "MakePolymakePolytopeVRep", function( vertices, lineality )
+    return Objectify( TheTypeOfPolymakePolytope,
+            rec( vertices := vertices,
+                 lineality := lineality,
+                 number_type := "rational",
+                 rep_type := "V-rep" ) );
+end);
+
+BindGlobal( "MakePolymakePolytopeHRep", function( inequalities, equalities )
+    return Objectify( TheTypeOfPolymakePolytope,
+            rec( inequalities := inequalities,
+                 equalities := equalities,
+                 number_type := "rational",
+                 rep_type := "H-rep" ) );
+end);
+
 
 ##############################################################################################
 ##
@@ -54,11 +70,7 @@ InstallGlobalFunction( Polymake_PolytopeByGenerators,
             Error( "Wronge input: The second argument should be a Gap matrix!" );
         fi;
         
-        poly := rec( vertices := arg[ 1 ],
-                     lineality := arg[ 2 ],
-                     number_type := "rational",
-                     rep_type := "V-rep" );
-        ObjectifyWithAttributes( poly, TheTypeOfPolymakePolytope );
+        poly := MakePolymakePolytopeVRep( arg[ 1 ], arg[ 2 ] );
         return Polymake_CanonicalPolytopeByGenerators( poly );
         
     fi;
@@ -88,11 +100,7 @@ InstallGlobalFunction( Polymake_PolytopeFromInequalities,
             Error( "Wronge input: The second argument should be a Gap matrix!" );
         fi;
         
-        poly := rec( inequalities := arg[ 1 ],
-                     equalities := arg[ 2 ],
-                     number_type := "rational",
-                     rep_type := "H-rep" );
-        ObjectifyWithAttributes( poly, TheTypeOfPolymakePolytope );
+        poly := MakePolymakePolytopeHRep( arg[ 1 ], arg[ 2 ] );
         return Polymake_CanonicalPolytopeFromInequalities( poly );
         
     fi;
@@ -153,11 +161,7 @@ InstallMethod( Polymake_CanonicalPolytopeByGenerators,
         od;
         
         # construct the new poly
-        new_poly := rec( vertices := scaled_vertices,
-                         lineality := scaled_lineality,
-                         number_type := "rational",
-                         rep_type := "V-rep" );
-        ObjectifyWithAttributes( new_poly, TheTypeOfPolymakePolytope );
+        new_poly := MakePolymakePolytopeVRep( scaled_vertices, scaled_lineality );
         return new_poly;
         
     fi;
@@ -206,11 +210,7 @@ InstallMethod( Polymake_CanonicalPolytopeFromInequalities,
         od;
         
         # construct the new poly
-        new_poly := rec( inequalities := scaled_ineqs,
-                         equalities := scaled_eqs,
-                         number_type := "rational",
-                         rep_type := "H-rep" );
-        ObjectifyWithAttributes( new_poly, TheTypeOfPolymakePolytope );
+        new_poly := MakePolymakePolytopeHRep( scaled_ineqs, scaled_eqs );
         return new_poly;
         
     fi;
@@ -270,11 +270,7 @@ InstallMethod( Polymake_V_Rep,
         od;
         
         # construct the new poly
-        new_poly := rec( vertices := scaled_vertices,
-                         lineality := scaled_lineality,
-                         number_type := "rational",
-                         rep_type := "V-rep" );
-        ObjectifyWithAttributes( new_poly, TheTypeOfPolymakePolytope );
+        new_poly := MakePolymakePolytopeVRep( scaled_vertices, scaled_lineality );
         return new_poly;
         
     fi;
@@ -328,11 +324,7 @@ InstallMethod( Polymake_H_Rep,
         od;
         
         # construct the new poly
-        new_poly := rec( inequalities := scaled_ineqs,
-                         equalities := scaled_eqs,
-                         number_type := "rational",
-                         rep_type := "H-rep" );
-        ObjectifyWithAttributes( new_poly, TheTypeOfPolymakePolytope );
+        new_poly := MakePolymakePolytopeHRep( scaled_ineqs, scaled_eqs );
         return new_poly;
         
     fi;

--- a/JConvex/gap/ExternalPolymakePolytope.gi
+++ b/JConvex/gap/ExternalPolymakePolytope.gi
@@ -25,19 +25,27 @@ BindGlobal( "TheFamilyOfPolymakePolytopes", NewFamily( "TheFamilyOfPolymakePolyt
 BindGlobal( "TheTypeOfPolymakePolytope", NewType( TheFamilyOfPolymakePolytopes, IsPolymakePolytopeRep ) );
 
 BindGlobal( "MakePolymakePolytopeVRep", function( vertices, lineality )
-    return Objectify( TheTypeOfPolymakePolytope,
+    local poly;
+    poly := Objectify( TheTypeOfPolymakePolytope,
             rec( vertices := Immutable( vertices ),
                  lineality := Immutable( lineality ),
                  number_type := "rational",
                  rep_type := "V-rep" ) );
+
+    poly!.pmobj := JuliaEvalString( Polymake_V_Rep_command_string( poly ) );
+    return poly;
 end);
 
 BindGlobal( "MakePolymakePolytopeHRep", function( inequalities, equalities )
-    return Objectify( TheTypeOfPolymakePolytope,
+    local poly;
+    poly := Objectify( TheTypeOfPolymakePolytope,
             rec( inequalities := Immutable( inequalities ),
                  equalities := Immutable( equalities ),
                  number_type := "rational",
                  rep_type := "H-rep" ) );
+
+    poly!.pmobj := JuliaEvalString( Polymake_H_Rep_command_string( poly ) );
+    return poly;
 end);
 
 

--- a/JConvex/gap/ExternalPolymakePolytope.gi
+++ b/JConvex/gap/ExternalPolymakePolytope.gi
@@ -25,26 +25,74 @@ BindGlobal( "TheFamilyOfPolymakePolytopes", NewFamily( "TheFamilyOfPolymakePolyt
 BindGlobal( "TheTypeOfPolymakePolytope", NewType( TheFamilyOfPolymakePolytopes, IsPolymakePolytopeRep ) );
 
 BindGlobal( "MakePolymakePolytopeVRep", function( vertices, lineality )
-    local poly;
+    local poly, kwargs, new_vertices, new_lin, v;
     poly := Objectify( TheTypeOfPolymakePolytope,
             rec( vertices := Immutable( vertices ),
                  lineality := Immutable( lineality ),
                  number_type := "rational",
                  rep_type := "V-rep" ) );
 
-    poly!.pmobj := JuliaEvalString( Polymake_V_Rep_command_string( poly ) );
+    # add 1s at the beginning, since Polymake always considers polytopes as intersections with the hyperplane x0 = 1
+    new_vertices := [];
+    for v in vertices do
+        v := ShallowCopy( v );
+        Add( v, 1, 1 );
+        Add( new_vertices, v );
+    od;
+    new_lin := [];
+    for v in lineality do
+        v := ShallowCopy( v );
+        Add( v, 1, 1 );
+        Add( new_lin, v );
+    od;
+
+    kwargs := rec();
+
+    # TODO: verify that kwargs is set correctly, also if one or both lists are empty
+
+    # check for degenerate case
+    if Length( new_vertices ) > 0 then
+        kwargs.POINTS := JuliaMatrixInt( new_vertices );
+
+        # if we also have lineality, add them
+        if Length( new_lin ) > 0 then
+            kwargs.INPUT_LINEALITY := JuliaMatrixInt( new_lin );
+        fi;
+    elif Length( new_lin ) > 0 then
+        kwargs.POINTS := JuliaMatrixInt( new_lin );
+        kwargs.INPUT_LINEALITY := kwargs.POINTS;
+    fi;
+
+    poly!.pmobj := CallJuliaFunctionWithKeywordArguments( _Polymake_jl.polytope.Polytope, [], kwargs );
     return poly;
 end);
 
 BindGlobal( "MakePolymakePolytopeHRep", function( inequalities, equalities )
-    local poly;
+    local poly, kwargs;
     poly := Objectify( TheTypeOfPolymakePolytope,
             rec( inequalities := Immutable( inequalities ),
                  equalities := Immutable( equalities ),
                  number_type := "rational",
                  rep_type := "H-rep" ) );
 
-    poly!.pmobj := JuliaEvalString( Polymake_H_Rep_command_string( poly ) );
+    kwargs := rec();
+
+    # TODO: verify that kwargs is set correctly, also if one or both lists are empty
+
+    # check for degenerate case
+    if Length( inequalities ) > 0 then
+        kwargs.INEQUALITIES := JuliaMatrixInt( inequalities );
+
+        # check if we also need equalities
+        if Length( equalities ) > 0 then
+            kwargs.EQUATIONS := JuliaMatrixInt( equalities );
+        fi;
+    elif Length( equalities ) > 0 then
+        kwargs.INEQUALITIES := JuliaMatrixInt( equalities );
+        kwargs.EQUATIONS := kwargs.INEQUALITIES;
+    fi;
+
+    poly!.pmobj := CallJuliaFunctionWithKeywordArguments( _Polymake_jl.polytope.Polytope, [], kwargs );
     return poly;
 end);
 
@@ -469,95 +517,4 @@ InstallMethod( Polymake_IsBounded,
   function( poly )
     return poly!.pmobj.BOUNDED;
     
-end );
-
-
-##############################################################################################
-##
-##  Command strings
-##
-##############################################################################################
-
-InstallMethod( Polymake_V_Rep_command_string,
-               "construct command string for V-Representation of polytope in Julia",
-               [ IsPolymakePolytope ],
-  function( poly )
-    local vertices, lin, new_vertices, new_lin, i, v, command_string;
-        
-        # check if the given poly is a V-rep
-        if not ( poly!.rep_type = "V-rep" ) then
-            return "fail";
-        fi;
-        
-        # extract data
-        vertices := poly!.vertices;
-        lin := poly!.lineality;
-        
-        # add 1s at the beginning, since Polymake always considers polytopes as intersections with the hyperplane x0 = 1
-        new_vertices := [];
-        for i in [ 1 .. Length( vertices ) ] do
-            v := ShallowCopy( vertices[ i ] );
-            Add( v, 1, 1 );
-            Add( new_vertices, v );
-        od;
-        new_lin := [];
-        for i in [ 1 .. Length( lin ) ] do
-            v := ShallowCopy( lin[ i ] );
-            Add( v, 1, 1 );
-            Add( new_lin, v );
-        od;
-        
-        # check for degenerate case
-        if Length( new_vertices ) = 0 then
-            new_vertices := new_lin;
-        fi;
-        
-        # prepare string with vertices -- as polymake considers them affine, we have to add a 1 at the beginning
-        new_vertices := List( [ 1 .. Length( new_vertices ) ], i -> ReplacedString( ReplacedString( ReplacedString( String( new_vertices[ i ] ), ",", "" ), "[ ", "" ), " ]", "" ) );
-        command_string := Concatenation( "PolytopeByGAP4PackageConvex", " = Polymake.polytope.Polytope( POINTS = [ ", JoinStringsWithSeparator( new_vertices, "; " ), "] " );
-        
-        # see if we need lineality
-        if ( Length( new_lin ) > 0 ) then
-            new_lin := List( [ 1 .. Length( new_lin ) ], i -> ReplacedString( ReplacedString( ReplacedString( String( new_lin[ i ] ), ",", "" ), "[ ", "" ), " ]", "" ) );
-            command_string := Concatenation( command_string, ", INPUT_LINEALITY = [ ", JoinStringsWithSeparator( new_lin, "; " ), " ] " );
-        fi;
-        
-        # return command string
-        return Concatenation( command_string, ")" );
-        
-end );
-
-InstallMethod( Polymake_H_Rep_command_string,
-               "construct command string for H-Representation of polytope in Julia",
-               [ IsPolymakePolytope ],
-  function( poly )
-    local ineqs, eqs, command_string;
-    
-        # check if the given poly is a V-rep
-        if not ( poly!.rep_type = "H-rep" ) then
-            return fail;
-        fi;
-        
-        # extract data
-        ineqs := poly!.inequalities;
-        eqs := poly!.equalities;
-        
-        # check for degenerate case
-        if Length( ineqs ) = 0 then
-            ineqs := eqs;
-        fi;
-        
-        # prepare string with inequalities
-        ineqs := List( [ 1 .. Length( ineqs ) ], i -> ReplacedString( ReplacedString( ReplacedString( String( ineqs[ i ] ), ",", "" ), "[ ", "" ), " ]", "" ) );
-        command_string := Concatenation( "PolytopeByGAP4PackageConvex", " = Polymake.polytope.Polytope( INEQUALITIES = [ ", JoinStringsWithSeparator( ineqs, "; " ), " ] " );
-        
-        # check if we also need equalities
-        if ( Length( eqs ) > 0 ) then
-            eqs := List( [ 1 .. Length( eqs ) ], i -> ReplacedString( ReplacedString( ReplacedString( String( eqs[ i ] ), ",", "" ), "[ ", "" ), " ]", "" ) );
-            command_string := Concatenation( command_string, ", EQUATIONS = [ ", JoinStringsWithSeparator( eqs, "; " ), " ] " );
-        fi;
-        
-        # return command string
-        return Concatenation( command_string, ")" );
-        
 end );

--- a/JConvex/gap/Functions.gi
+++ b/JConvex/gap/Functions.gi
@@ -18,21 +18,17 @@
 ##
 InstallMethod( PolymakeAvailable, [  ],
   function( )
-    local available;
-    available := false;
-
     # Check if Polymake and the gap-julia interface are available
-    if ( TestPackageAvailability( "JuliaInterface", ">= 0.5.2" ) <> fail ) then
-        if IsPackageMarkedForLoading( "JuliaInterface", ">= 0.5.2" ) then
-            if JuliaImportPackage("Polymake") then
-                available := true;
-                ImportJuliaModuleIntoGAP( "Polymake" );
-            fi;
+    if IsPackageMarkedForLoading( "JuliaInterface", ">= 0.5.2" ) then
+        if IsBoundGlobal("_Polymake_jl") and IsJuliaObject(ValueGlobal("_Polymake_jl")) then
+            return true;
+        fi;
+        if JuliaEvalString("try import Polymake ; return true\ncatch\n return false end") then
+            BindGlobal("_Polymake_jl", JuliaPointer(Julia.Polymake));
+            return true;
         fi;
     fi;
-
-    return available;
-
+    return false;
 end );
 
 ##


### PR DESCRIPTION
- Only call PolymakeAvailable() once
- Remove redundant TestPackageAvailability calls
- Add MakePolymake{Cone,Polytope}[HV]Rep
- Make object components immutable
- Enhance PolymakeAvailable
- Create a Polymake counterpart when creating objects
- Use precomputed Polymake objects
- Create Polymake objects without JuliaEvalString
- Convert polymake matrices to GAP matrices directly


This contains PR #151