### PR TITLE
Speed optimization

### DIFF
--- a/QSMExplorer/bin/RootCounter/HiggsDistributionCounter.cpp
+++ b/QSMExplorer/bin/RootCounter/HiggsDistributionCounter.cpp
@@ -13,6 +13,16 @@ void compute_distribution(
         std::vector<boost::multiprecision::int128_t> & final_dist,
         std::vector<int> & status
         );
+void compute_diagonal_distribution(
+        std::vector<std::vector<unsigned long long int>> outfluxes_H1filtered,
+        std::vector<std::vector<unsigned long long int>> outfluxes_H2filtered,
+        std::vector<std::vector<boost::multiprecision::int128_t>> dist_H1filtered,
+        std::vector<std::vector<boost::multiprecision::int128_t>> dist_H2filtered,
+        std::vector<int> legs_per_component_halved,
+        std::vector<int> integer_data,
+        std::vector<boost::multiprecision::int128_t> & final_dist,
+        std::vector<int> & status
+        );
 void status_updater( std::vector<int> & status );
 
 
@@ -70,36 +80,36 @@ void compute_distribution(
     std::vector<int> change ( status.size(), 0 );
     
     // (2) Form H1 map for quick access (-> Hash table)
-    std::map<std::vector<unsigned long long int>, std::vector<boost::multiprecision::int128_t>> mapH1;
-    for ( int i = 0; i < outfluxes_H1filtered.size(); i ++ ){
-        mapH1.insert( std::make_pair( outfluxes_H1filtered[ i ], dist_H1filtered[ i ] ) );
+    std::map<std::vector<unsigned long long int>, std::vector<boost::multiprecision::int128_t>> mapH2;
+    for ( int i = 0; i < outfluxes_H2filtered.size(); i ++ ){
+        mapH2.insert( std::make_pair( outfluxes_H2filtered[ i ], dist_H2filtered[ i ] ) );
     }
     
     // (3) Loop over H1-fluxes
     for ( int i = start; i <= stop; i++ ){
 
-        // (3.1) Loop over H2 fluxes
-        for ( int j = 0; j < outfluxes_H2filtered.size(); j++ ){
+        // (3.1) Loop over H3 fluxes
+        for ( int j = i+1; j < outfluxes_H1filtered.size(); j++ ){
             
-            // (3.1.1) Compute H3 flux f3
-            std::vector<unsigned long long int> f3;
+            // (3.1.1) Compute H2 flux f2
+            std::vector<unsigned long long int> f2;
             for ( int c = 0; c < number_components; c++ ){
-                f3.push_back( (unsigned long long int) ( 3 *  legs_per_component_halved[ c ] * root - outfluxes_H1filtered[ i ][ c ] - outfluxes_H2filtered[ j ][ c ] ) );
+                f2.push_back( (unsigned long long int) ( 3 *  legs_per_component_halved[ c ] * root - outfluxes_H1filtered[ i ][ c ] - outfluxes_H1filtered[ j ][ c ] ) );
             }
             
-            // (3.1.2) Only proceed if H3 flux f3 has non-trivial distribution
-            if ( mapH1.find( f3 ) != mapH1.end() ){
+            // (3.1.2) Only proceed if H2 flux f2 has non-trivial distribution
+            if ( mapH2.find( f2 ) != mapH2.end() ){
 
                 // Compute combinatorial factor
                 boost::multiprecision::int128_t factor = 1;
                 for ( int c = 0; c < number_components; c++ ){
-                    factor = factor * ( boost::multiprecision::int128_t ) comb_factor( outfluxes_H1filtered[ i ][ c ], outfluxes_H2filtered[ j ][ c ], legs_per_component_halved[ c ], root );
+                    factor = factor * ( boost::multiprecision::int128_t ) comb_factor( outfluxes_H1filtered[ i ][ c ], f2[ c ], legs_per_component_halved[ c ], root );
                 }
                 
                 // Update resulting distribution
                 d1 = dist_H1filtered[ i ];
-                d2 = dist_H2filtered[ j ];
-                d3 = mapH1[ f3 ];
+                d2 = mapH2[ f2 ];
+                d3 = dist_H1filtered[ j ];
                 for ( int a1 = 0; a1 < d1.size(); a1++ ){
                     for ( int a2 = 0; a2 < d2.size(); a2++ ){
                         for ( int a3 = 0; a3 < d3.size(); a3++ ){
@@ -127,7 +137,98 @@ void compute_distribution(
 
     }
     
-    // (4) Update central distribution result
+    // (4) Final steps - multiply by 2 (symmetry factor) and report results
+    for ( int i = 0; i < res.size(); i++ ){
+        res[ i ] = ( (boost::multiprecision::int128_t) 2 ) * res[ i ];
+    }
     UpdateDistributionThreadSafe( final_dist, res );
         
+}
+
+
+// H1-diag-iterator
+// H1-diag-iterator
+void compute_diagonal_distribution( 
+        std::vector<std::vector<unsigned long long int>> outfluxes_H1filtered,
+        std::vector<std::vector<unsigned long long int>> outfluxes_H2filtered,
+        std::vector<std::vector<boost::multiprecision::int128_t>> dist_H1filtered,
+        std::vector<std::vector<boost::multiprecision::int128_t>> dist_H2filtered,
+        std::vector<int> legs_per_component_halved,
+        std::vector<int> integer_data,
+        std::vector<boost::multiprecision::int128_t> & final_dist,
+        std::vector<int> & status ){
+    
+    // (0) Extract integer data
+    int root = integer_data[ 0 ];
+    int start = integer_data[ 1 ];
+    int stop = integer_data[ 2 ];
+    int thread_number = integer_data[ 3 ];
+    
+    // (1) Set variables
+    std::vector<boost::multiprecision::int128_t> res( final_dist.size(), 0 );
+    int progress = 0;
+    int number_components = legs_per_component_halved.size();
+    std::vector<unsigned long long int> f1, f2, f3;
+    std::vector<boost::multiprecision::int128_t> d1, d2, d3;
+    std::vector<int> change ( status.size(), 0 );
+    
+    // (2) Form H1 map for quick access (-> Hash table)
+    std::map<std::vector<unsigned long long int>, std::vector<boost::multiprecision::int128_t>> mapH2;
+    for ( int i = 0; i < outfluxes_H2filtered.size(); i ++ ){
+        mapH2.insert( std::make_pair( outfluxes_H2filtered[ i ], dist_H2filtered[ i ] ) );
+    }
+    
+    // (3) Loop over H1-fluxes
+    for ( int i = start; i <= stop; i++ ){
+
+        // (3.1) Pick H3-flux
+        int j = i;
+            
+        // (3.1.1) Compute H2 flux f2
+        std::vector<unsigned long long int> f2;
+        for ( int c = 0; c < number_components; c++ ){
+            f2.push_back( (unsigned long long int) ( 3 *  legs_per_component_halved[ c ] * root - outfluxes_H1filtered[ i ][ c ] - outfluxes_H1filtered[ j ][ c ] ) );
+        }
+        
+        // (3.1.2) Only proceed if H2 flux f2 has non-trivial distribution
+        if ( mapH2.find( f2 ) != mapH2.end() ){
+            
+            // Compute combinatorial factor
+            boost::multiprecision::int128_t factor = 1;
+            for ( int c = 0; c < number_components; c++ ){
+                factor = factor * ( boost::multiprecision::int128_t ) comb_factor( outfluxes_H1filtered[ i ][ c ], f2[ c ], legs_per_component_halved[ c ], root );
+            }
+            
+            // Update resulting distribution
+            d1 = dist_H1filtered[ i ];
+            d2 = mapH2[ f2 ];
+            d3 = dist_H1filtered[ j ];
+            for ( int a1 = 0; a1 < d1.size(); a1++ ){
+                for ( int a2 = 0; a2 < d2.size(); a2++ ){
+                    for ( int a3 = 0; a3 < d3.size(); a3++ ){
+                        if ( ( d1[ a1 ] != 0 ) && ( d2[ a2 ] != 0 ) && ( d3[ a3 ] != 0 ) && ( a1 + a2 + a3 < res.size() ) ){
+                            res[ a1 + a2 + a3 ] = res[ a1 + a2 + a3 ] + factor * (boost::multiprecision::int128_t ) d1[ a1 ] * (boost::multiprecision::int128_t) d2[ a2 ] * (boost::multiprecision::int128_t) d3[ a3 ];
+                        }
+                    }
+                }
+            }
+        }
+        
+        // (3.2) Signal progress
+        if ( start == stop ){
+            progress = 100;
+            UpdateStatusThreadSafe( status, progress, thread_number );
+        }
+        else{
+            if ( progress < int ( 100 * ( i - start ) / ( stop - start ) ) ){
+                progress = int ( 100 * ( i - start ) / ( stop - start ) );
+                UpdateStatusThreadSafe( status, progress, thread_number );
+            }
+        }
+
+    }
+    
+    // (4) Final steps - report results
+    UpdateDistributionThreadSafe( final_dist, res );
+    
 }

--- a/QSMExplorer/bin/RootCounter/HiggsMain.cpp
+++ b/QSMExplorer/bin/RootCounter/HiggsMain.cpp
@@ -219,7 +219,7 @@ int main(int argc, char* argv[]) {
     std::vector<std::vector<boost::multiprecision::int128_t>> dist_H1, dist_H2;
     std::vector<int> status( number_threads, 0 );
     int package_size = all_outfluxes.size() / number_threads;
-    std::vector<boost::thread> threadList;
+    boost::thread_group threadList;
     int start, stop;
     
     // (3.2) Partition workload and start threads
@@ -237,14 +237,11 @@ int main(int argc, char* argv[]) {
         }
         
         // Start thread
-        threadList.push_back( boost::thread( &FluxScanner, all_outfluxes, boost::ref( outfluxes_H1 ),  boost::ref( outfluxes_H2 ),  boost::ref( dist_H1 ), boost::ref( dist_H2 ), boost::ref( status ), input, i, interval ) );
+        boost::thread *t = new boost::thread( FluxScanner, all_outfluxes, boost::ref( outfluxes_H1 ),  boost::ref( outfluxes_H2 ),  boost::ref( dist_H1 ), boost::ref( dist_H2 ), boost::ref( status ), input, i, interval );
+        threadList.add_thread( t );
         
     }
-    
-    // join all these threads
-    for ( int i = 0; i < threadList.size(); i++ ){        
-        threadList[ i ].join();
-    }
+    threadList.join_all();
     
     // (3.3) Inform what we have achieved
     std::chrono::steady_clock::time_point middle = std::chrono::steady_clock::now();

--- a/QSMExplorer/bin/RootCounter/HiggsMain.cpp
+++ b/QSMExplorer/bin/RootCounter/HiggsMain.cpp
@@ -264,41 +264,65 @@ int main(int argc, char* argv[]) {
     std::vector<boost::multiprecision::int128_t> final_dist( h0Max + 1, 0 );
     
     // (5) Partition workload and start threads
-    package_size = outfluxes_H1.size() / number_threads;
-    std::vector<boost::thread> threadList2;
+    boost::thread_group threadList2;
+    //std::vector<boost::thread> threadList2;
     for ( int i = 0; i < status.size(); i++ ){
         status[ i ] = 0;
     }
-    for ( int i = 0; i < number_threads; i++)
-    {
-
-        // Gather integer data
-        start = i * package_size;
-        if ( i < number_threads - 1 ){
-            stop = ( i + 1 ) * package_size - 1;
-        }
-        else{
-            stop = (int) outfluxes_H1.size() - 1;
-        }
-        std::vector<int> integer_data = { root, start, stop, i };
+    if ( number_threads > 1 ){
         
-        // Start the worker threads
-        threadList2.push_back( boost::thread( &compute_distribution,
-                                                                    outfluxes_H1,
-                                                                    outfluxes_H2,
-                                                                    dist_H1,
-                                                                    dist_H2,
-                                                                    legs_per_component_halved,
-                                                                    integer_data,
-                                                                    std::ref( final_dist ),
-                                                                    std::ref( status )
-                                                                ) );
+        // start threads to iterate over non-diagonal fluxes (f1,f3)
+        boost::multiprecision::int128_t total_number_tasks = ( boost::multiprecision::int128_t ) ( outfluxes_H1.size() * ( outfluxes_H1.size() - 1 ) / 2 );
+        boost::multiprecision::int128_t average_number_tasks = total_number_tasks / ( number_threads - 1 );
+        int start = 0;
+        for ( int i = 0; i < number_threads - 1; i++)
+        {
+            
+            int pos = start - 1;
+            int tasks = 0;
+            if ( i < number_threads - 2 ){
+                
+                while ( tasks < average_number_tasks ){            
+                    pos = pos + 1;
+                    tasks = tasks + outfluxes_H1.size() - ( pos + 1 );
+                }
+                stop = pos;
+                
+            }
+            else{
+                
+                stop = outfluxes_H1.size() - 1;
+                
+            }
+            std::vector<int> integer_data = { root, start, stop, i };
+            
+            // Start the worker threads
+            boost::thread *t = new boost::thread( compute_distribution, outfluxes_H1, outfluxes_H2, dist_H1, dist_H2, legs_per_component_halved, integer_data, std::ref( final_dist ), std::ref( status ) );
+            threadList2.add_thread( t );
+            //threadList2.add_thread( boost::thread( &compute_distribution, outfluxes_H1, outfluxes_H2, dist_H1, dist_H2, legs_per_component_halved, integer_data, std::ref( final_dist ), std::ref( status ) ) );
+            
+            // increase start
+            start = pos + 1;
+            
+        }
+        
+        // start diagonal thread
+        std::vector<int> integer_data = { root, 0, (int) outfluxes_H1.size() - 1, number_threads - 1 };
+        boost::thread *t = new boost::thread( compute_diagonal_distribution, outfluxes_H1, outfluxes_H2, dist_H1, dist_H2, legs_per_component_halved, integer_data, std::ref( final_dist ), std::ref( status ) );
+        threadList2.add_thread( t );
+        //threadList2.add_thread( boost::thread( &compute_diagonal_distribution, outfluxes_H1, outfluxes_H2, dist_H1, dist_H2, legs_per_component_halved, integer_data, std::ref( final_dist ), std::ref( status ) ) );
+        
+        // join all these threads
+        threadList2.join_all();
         
     }
-    
-    // join all these threads
-    for ( int i = 0; i < threadList2.size(); i++ ){        
-        threadList2[ i ].join();
+    else{
+        
+        // sequentially perform two tasks after each other
+        std::vector<int> integer_data = { root, 0, (int) outfluxes_H1.size() - 1, 0 };
+        compute_distribution( outfluxes_H1, outfluxes_H2, dist_H1, dist_H2, legs_per_component_halved, integer_data, final_dist, status );
+        compute_diagonal_distribution( outfluxes_H1, outfluxes_H2, dist_H1, dist_H2, legs_per_component_halved, integer_data, final_dist, status );
+        
     }
     
     // (6) Print result

--- a/QSMExplorer/makefile
+++ b/QSMExplorer/makefile
@@ -35,7 +35,13 @@ install-with-links-to-local-boost: uninstall
 	( cd bin/RootCounter && g++ -c -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread WDiagram.cpp; )
 	( cd bin/RootCounter && g++ -c -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread main.cpp && g++ -o distributionCounter WDiagram.o main.o -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread )
 	( cd bin/RootCounter && g++ -c -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread HiggsMain.cpp && g++ -o distributionCounterHiggsCurve WDiagram.o HiggsMain.o -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread )
-
+    
+install-with-links-to-local-boost-and-profiling: uninstall
+	( cd bin/RootCounter && g++ -pg -c main-speciality.cpp && g++ -pg -o specialityChecker main-speciality.o )
+	( cd bin/RootCounter && g++ -pg -c -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread WDiagram.cpp; )
+	( cd bin/RootCounter && g++ -pg -c -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread main.cpp && g++ -pg -o distributionCounter WDiagram.o main.o -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread )
+	( cd bin/RootCounter && g++ -pg -c -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread HiggsMain.cpp && g++ -pg -o distributionCounterHiggsCurve WDiagram.o HiggsMain.o -Wl,-rpath=${P1} -I${P2} -L${P1} -lboost_thread -lboost_system -lpthread )
+	
 install: uninstall
 	( cd bin/RootCounter && g++ -c -lboost_thread WDiagram.cpp )
 	( cd bin/RootCounter && g++ -c main-speciality.cpp && g++ -o specialityChecker main-speciality.o )


### PR DESCRIPTION
Scan over H1 and H3 fluxes (instead of H1 and H2 fluxes) and use symmetry among H1, H3 to improve the speed of the root distribution counter on the Higgs curve.