### PR TITLE
Enable some README.md links

### DIFF
--- a/H0Approximator/README.md
+++ b/H0Approximator/README.md
@@ -4,11 +4,11 @@ A gap package to estimate the global sections of a pullback line bundle on a hyp
 ## Acknowledgement
 
 This algorithm is the result of ongoing collaboration with
-* Mirjam Cvetič (https://live-sas-physics.pantheon.sas.upenn.edu/people/standing-faculty/mirjam-cvetic)
-* Ron Donagi (https://www.math.upenn.edu/~donagi/)
-* Ling Lin (https://theory.cern/roster/lin-ling)
-* Muyang Liu (https://github.com/lmyreg2017)
-* Fabian Rühle (https://theory.cern/roster/ruehle-fabian)
+* [Mirjam Cvetič](https://live-sas-physics.pantheon.sas.upenn.edu/people/standing-faculty/mirjam-cvetic)
+* [Ron Donagi](https://www.math.upenn.edu/~donagi/)
+* [Ling Lin](https://theory.cern/roster/lin-ling)
+* [Muyang Liu](https://github.com/lmyreg2017)
+* [Fabian Rühle](https://theory.cern/roster/ruehle-fabian)
 
 The corresponding preprint is available [here](https://arxiv.org/abs/2007.00009). Related -- you may find our [database](https://github.com/Learning-line-bundle-cohomology/Database) useful.
 

--- a/QSMExplorer/README.md
+++ b/QSMExplorer/README.md
@@ -4,16 +4,16 @@ A package to explor one Quadrillion F-theory Standard Models.
 ## Acknowledgements
 
 This algorithm is the result of ongoing collaboration with
-* Martin Bies (https://martinbies.github.io/)
-* Mirjam Cvetič (https://live-sas-physics.pantheon.sas.upenn.edu/people/standing-faculty/mirjam-cvetic)
-* Muyang Liu (https://www.sas.upenn.edu/heptheory/node/392)
+* [Martin Bies](https://martinbies.github.io/)
+* [Mirjam Cvetič](https://live-sas-physics.pantheon.sas.upenn.edu/people/standing-faculty/mirjam-cvetic)
+* [Muyang Liu](https://www.sas.upenn.edu/heptheory/node/392)
 
 The corresponding preprint is available at [2104.08297](https://arxiv.org/pdf/2104.08297.pdf).
 
 
 ## Installation
 
-To get the latest version of this GAP 4 package pull the corresponding repository from github. Subsequently issue `make install` inside the package folder. It will compile `C++`-code and place the resutling binary `counter` in the subfolder `/bin/RootCounter`. This completes the installation of this package.
+To get the latest version of this GAP 4 package pull the corresponding repository from github. Subsequently issue `make install` inside the package folder. It will compile `C++`-code and place the resulting binary `counter` in the subfolder `/bin/RootCounter`. This completes the installation of this package.
 
 To handle large integers (10^20 and higher), we use the [boost library](https://www.boost.org/). The simplest way to install this library on Ubuntu systems is via `sudo apt-get install libboost-all-dev`. Once this is achieve, just issue `make install` to build the binaries use for limit root counting. Alternatively, we can download the boost library and build it from source. An attempt to provide an automated approach towards this goal is provided via `make install-with-boost-from-source`.
 


### PR DESCRIPTION
The links on e.g. https://homalg-project.github.io/ToricVarieties_project/QSMExplorer/ were not clickable before
