### PR TITLE
Revise PackageInfo.g files

### DIFF
--- a/AdditionsForToricVarieties/PackageInfo.g
+++ b/AdditionsForToricVarieties/PackageInfo.g
@@ -45,11 +45,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/homalg-project/ToricVarieties_project/tree/master/AdditionsForToricVarieties/",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/AdditionsForToricVarieties",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "AdditionsForToricVarieties provides additional structures for toric varieties required to compute sheaf cohomologies",
 

--- a/CoherentSheavesOnToricVarieties/PackageInfo.g
+++ b/CoherentSheavesOnToricVarieties/PackageInfo.g
@@ -45,11 +45,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/homalg-project/ToricVarieties_project/tree/master/CoherentSheavesOnToricVarieties/",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/CoherentSheavesOnToricVarieties",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "CoherentSheavesOnToricVarieties models coherent toric sheaves as elements in a Serre quotient category",
 

--- a/H0Approximator/PackageInfo.g
+++ b/H0Approximator/PackageInfo.g
@@ -66,11 +66,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/homalg-project/ToricVarieties_project/tree/master/H0Approximator/",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/H0Approximator",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "H0Approximator allows to estimate global sections of a line bundle on curves in dP3 and H2",
 

--- a/QSMExplorer/PackageInfo.g
+++ b/QSMExplorer/PackageInfo.g
@@ -66,11 +66,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://homalg-project.github.io/ToricVarieties_project/QSMExplorer",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/QSMExplorer",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "QSMExplorer allows to investigate one Quadrillion F-theory Standard Models quickly and efficiently",
 

--- a/SheafCohomologyOnToricVarieties/PackageInfo.g
+++ b/SheafCohomologyOnToricVarieties/PackageInfo.g
@@ -45,11 +45,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/homalg-project/ToricVarieties_project/tree/master/SheafCohomologyOnToricVarieties/",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/SheafCohomologyOnToricVarieties",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := 
   Concatenation( "SheafCohomologyOnToricVarieties provides an extension of the ToricVarieties package",

--- a/SparseMatrices/PackageInfo.g
+++ b/SparseMatrices/PackageInfo.g
@@ -45,11 +45,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/homalg-project/ToricVarieties_project/tree/master/SparseMatrices",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/SparseMatrices",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "SparseMatrices enables to handle sparse matrices in gap",
 

--- a/SpasmInterface/PackageInfo.g
+++ b/SpasmInterface/PackageInfo.g
@@ -45,11 +45,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/homalg-project/ToricVarieties_project/tree/master/SpasmInterface/",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/SpasmInterface",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "SpasmInterface enables to communicate with software Spasm via gap",
 

--- a/ToolsForFPGradedModules/PackageInfo.g
+++ b/ToolsForFPGradedModules/PackageInfo.g
@@ -45,11 +45,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/homalg-project/ToricVarieties_project/tree/master/ToolsForFPGradedModules/",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/ToolsForFPGradedModules",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "ToolsForFPGradedModules provides additional structures and tools for FPGradedModules",
 

--- a/TopcomInterface/PackageInfo.g
+++ b/TopcomInterface/PackageInfo.g
@@ -46,11 +46,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/HereAround/TopcomInterface",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/TopcomInterface",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "TopcomInterface enables to communicate with software Topcom via gap",
 

--- a/ToricVarieties/PackageInfo.g
+++ b/ToricVarieties/PackageInfo.g
@@ -61,16 +61,19 @@ rec(
 ],
 
 Status := "deposited",
+
 SourceRepository := rec(
-  Type := "git",
-  URL := "https://homalg-project.github.io/ToricVarieties_project/ToricVarieties"
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome := "https://homalg-project.github.io/ToricVarieties_project/ToricVarieties/",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/ToricVarieties",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := 
   Concatenation( "ToricVarieties provides data structures to handle toric varieties by their commutative algebra ",

--- a/TruncationsOfFPGradedModules/PackageInfo.g
+++ b/TruncationsOfFPGradedModules/PackageInfo.g
@@ -45,11 +45,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/homalg-project/ToricVarieties_project/tree/master/TruncationsOfFPGradedModules/",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/TruncationsOfFPGradedModules",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "TruncationsOfFPGradedModules provides methods to compute truncations of FPGradedModules",
 

--- a/cohomCalgInterface/PackageInfo.g
+++ b/cohomCalgInterface/PackageInfo.g
@@ -45,11 +45,19 @@ rec(
 ],
 
 Status := "dev",
-PackageWWWHome := "https://github.com/homalg-project/ToricVarieties_project/tree/master/cohomCalgInterface/",
-ArchiveFormats := ".tar.gz .zip",
-ArchiveURL     := "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/cohomCalgInterface",
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/homalg-project/ToricVarieties_project",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://homalg-project.github.io/ToricVarieties_project/", ~.PackageName ),
+ArchiveFormats  := ".tar.gz .zip",
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/", ReplacedString( ~.Version, ".", "-"),
+                                 "/", ~.PackageName, "-", ~.Version ),
+README_URL      := Concatenation( ~.PackageWWWHome, "README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := "cohomCalgInterface enables to communicate with software cohomCalg via gap",
 


### PR DESCRIPTION
- add `SourceRepository` and `IssueTrackerURL` fields
- point `PackageWWWHome` to actual package homepages
- don't duplicate package versions in the `ArchiveURL`, instead
  derive them from the `Version` field

This also changes the archive filenames to include the version, which is my main motivation for this PR: it is annoying when using the package distribution scripts when different package versions use the same tarball name.

For this renaming to work, of course your release scripts must generate and upload files with the "right" name. If you are using the same scripts as for homalg, which were originally derived from the ReleaseTools scripts, then this should automatically be the case. If not, I hope you can still adapt to this.

BTW, I would also suggest to drop the `.zip` from the `ArchiveFormats`, I don't think anyone needs those. But of course feel free to keep it if you prefer that for some reason.

