### PR TITLE
Tests for package ToricVarieties no longer use FreydCategories

### DIFF
--- a/ToricVarieties/tst/testall.g
+++ b/ToricVarieties/tst/testall.g
@@ -12,8 +12,6 @@ options := rec(
     ),
 );
 
-LoadPackage( "FreydCategoriesForCAP", false );
-
 TestDirectory( DirectoriesPackageLibrary( "ToricVarieties", "tst" ), options );
 
 FORCE_QUIT_GAP( 1 ); # if we ever get here, there was an error


### PR DESCRIPTION
This PR aims to address https://github.com/homalg-project/ToricVarieties_project/issues/185.